### PR TITLE
fix: unref timeout

### DIFF
--- a/src/delay.js
+++ b/src/delay.js
@@ -1,3 +1,3 @@
 module.exports = function delay(time) {
-    return new Promise(resolve => setTimeout(() => resolve(), time));
+    return new Promise(resolve => setTimeout(() => resolve(), time).unref());
 };


### PR DESCRIPTION
I tried using this library to close an http server like this:

```js
const http = require('http');
const HttpTerminator = require('lil-http-terminator');

const server = http.createServer((req, res) => {
  res.end('hello world');
});
const terminator = HttpTerminator({ server });

server.listen(3000);

const close = async () => console.log(await terminator.terminate());
process
  .on('SIGINT', close)
  .on('SIGTERM', close);
```

When I run this program in a terminal and press ctrl+c, the application doesn't stop until the full timeout passes (30 seconds by default). I can forcibly quit the server using `process.exit` or `process.kill`, but I think that I should be able to let the server exit naturally by freeing up the event loop.

Adding `unref` to the timeout makes this example work as expected - after pressing ctrl+c, the application will print that it has terminated and exit immediately.